### PR TITLE
Fix RestoreCBTModules never being cached

### DIFF
--- a/.build/CBT/build.props
+++ b/.build/CBT/build.props
@@ -107,7 +107,7 @@
   <Target Name="RestoreCBTModules"
       Condition=" '$(RestoreCBTModules)' != 'false' And '$(CBTModulesRestored)' != 'true' "
       Inputs="$(CBTModuleRestoreInputs)"
-      Outputs="$([MSBuild]::ValueOrDefault($(CBTModulePropertiesFile), 'null'))">
+      Outputs="$(CBTModulePropertiesFile)">
 
     <RestoreModules
       AfterImports="$(CBTModuleImportsAfter.Split(';'))"

--- a/src/CBT.Core.UnitTests/BuildPropsTest.cs
+++ b/src/CBT.Core.UnitTests/BuildPropsTest.cs
@@ -160,7 +160,7 @@ namespace CBT.Core.UnitTests
 
             target.Inputs.ShouldBe("$(CBTModuleRestoreInputs)");
 
-            target.Outputs.ShouldBe("$([MSBuild]::ValueOrDefault($(CBTModulePropertiesFile), 'null'))");
+            target.Outputs.ShouldBe("$(CBTModulePropertiesFile)");
 
             var task = target.Tasks.FirstOrDefault(i => i.Name.Equals("RestoreModules"));
 


### PR DESCRIPTION
The output path wasn't working so it would always be re-run.

This fixes #79.

(This change is safe because of [line 70](https://github.com/CommonBuildToolset/CBT.Core/pull/80/files#diff-722170f4e2717941035cc287ce7d519cL70).)